### PR TITLE
Enh/sff 79 new synthetic benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: clean build run
+.PHONY: clean build run bench
 
 cpp_dir = backend
 bold_magenta = \033[0;35m
 reset_col = \033[0m
+benchmark_prog = benchmark.py
 
 all: build
+
+bench: build
+	@printf "$(bold_magenta)>> Running Benchmark Suite <<$(reset_col)"
+	@printf "$(bold_magenta)>> python3 version 3.10+   <<$(reset_col)"
+	python3 $(benchmark_prog)
 
 run: build
 	@printf "$(bold_magenta)>> Running cabal side      <<$(reset_col)"

--- a/ProbFX-RoadMarkings.cabal
+++ b/ProbFX-RoadMarkings.cabal
@@ -43,7 +43,7 @@ library
 executable ProbFX-RoadMarkings
     buildable:        True
     main-is:          Detection.hs
-    build-depends:    base, prob-fx, ProbFX-RoadMarkings, fused-effects
+    build-depends:    base, prob-fx, ProbFX-RoadMarkings, fused-effects, random
 
     hs-source-dirs:   src
     other-modules:    Hough

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ wsl --shutdown
 # reopen wsl terminal to restart
 ```
 
+Python 3.10 is also required for benchmarking.
+
 ### Build & Clean
 To simplify the build process we use a makefile to invoke cabal
 ```bash
@@ -97,4 +99,10 @@ make       # same as make build
 make run
 make build
 make clean
+```
+
+### Benchmarking
+To run the synthetic benchmark suite
+```bash
+make bench
 ```

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT WIN32)
 endif()
 
 # Use openGL 4 if true, 3 is false
-set(OGL4 false)
+set(OGL4 true)
 
 if (${OGL4})
     message(STATUS "${Red} Building for OpenGL 4 ${ColourReset}")

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT WIN32)
 endif()
 
 # Use openGL 4 if true, 3 is false
-set(OGL4 true)
+set(OGL4 false)
 
 if (${OGL4})
     message(STATUS "${Red} Building for OpenGL 4 ${ColourReset}")

--- a/backend/src/bindings.cpp
+++ b/backend/src/bindings.cpp
@@ -9,9 +9,9 @@ void check_context() {
   }
 }
 
-void render_scene_c(struct scene *scene) {
+void render_scene_c(struct scene *scene, GLuint FBO) {
   check_context();
-  render_scene(scene);
+  render_scene(scene, FBO);
 }
 void set_target_img_c(const char *str) {
   check_context();
@@ -40,4 +40,18 @@ detected_lines_t *hough_lines_c(const char *str) {
 detected_lines_t *scene_lines_c(struct scene *scene) {
   check_context();
   return get_scene_geometry(scene);
+}
+struct texture_fbo *create_texture_fbo_c() {
+	check_context();
+	return create_texture_fbo();
+}
+
+GLuint get_scene_fbo_c() {
+	check_context();
+	return get_scene_fbo();
+}
+
+GLuint get_target_texture_c() {
+	check_context();
+	return get_target_texture();
 }

--- a/backend/src/bindings.h
+++ b/backend/src/bindings.h
@@ -1,10 +1,11 @@
 #ifndef BINDINGS_H
 #define BINDINGS_H
 
+#include <glad/glad.h>
 #include "hough.h"
 
 extern "C" {
-void render_scene_c(struct scene *scene);
+void render_scene_c(struct scene *scene, GLuint FBO);
 void set_target_img_c(const char *str);
 int test_bed_c(const char *str, double x, double y, double z, double pitch, double yaw,
                double roll);
@@ -12,6 +13,11 @@ double get_mean_pixel_value_c(int color);
 void find_texture_difference_c(int color);
 detected_lines_t *hough_lines_c(const char *str);
 detected_lines_t *scene_lines_c(struct scene *scene);
+
+struct texture_fbo *create_texture_fbo_c();
+GLuint get_scene_fbo_c();
+GLuint get_target_texture_c();
+
 }
 
 #endif

--- a/backend/src/render.cpp
+++ b/backend/src/render.cpp
@@ -60,19 +60,19 @@ int test_bed(const char *str, double x, double y, double z, double pitch, double
     // Renders into diffFBO where the texture is in diffTexture
     get_image_mask(context->sceneTexture, context->targetTexture, 0);
     double error1 = get_mean_pixel_value(context->diffTexture, 0);
-    std::cout << error1 << std::endl;
+    // std::cout << error1 << std::endl;
     for (int i = 0; i < 120; i++) {
       render_to_screen(context->diffTexture);
     }
     get_image_mask(context->sceneTexture, context->targetTexture, 1);
     double error2 = get_mean_pixel_value(context->diffTexture, 1);
-    std::cout << error2 << std::endl;
+    // std::cout << error2 << std::endl;
     for (int i = 0; i < 120; i++) {
       render_to_screen(context->diffTexture);
     }
     get_image_mask(context->sceneTexture, context->targetTexture, 2);
     double error3 = get_mean_pixel_value(context->diffTexture, 2);
-    std::cout << error3 << std::endl;
+    // std::cout << error3 << std::endl;
     for (int i = 0; i < 120; i++) {
       render_to_screen(context->diffTexture);
     }

--- a/backend/src/render.cpp
+++ b/backend/src/render.cpp
@@ -35,66 +35,62 @@ const char *MSE_COMPUTE_SHADER =
 #include "shaders/mse.computeshader"
 		;
 
-int test_bed(const char *str, double x, double y, double z, double pitch, double yaw,
-						 double roll)
-{
-	struct scene scene;
-	scene.camera.x = x;
-	scene.camera.y = y;
-	scene.camera.z = z;
-	scene.camera.pitch = pitch;
-	scene.camera.yaw = yaw;
-	scene.camera.roll = roll;
+int test_bed(const char *str, double x, double y, double z, double pitch, double yaw, double roll) {
+  struct scene scene;
+  scene.camera.x = x;
+  scene.camera.y = y;
+  scene.camera.z = z;
+  scene.camera.pitch = pitch;
+  scene.camera.yaw = yaw;
+  scene.camera.roll = roll;
 
-	// Seperate Load img function
-	set_target_img(str);
+  // Seperate Load img function
+  set_target_img(str);
 
-	while (!glfwWindowShouldClose(context->window))
-	{
-		for (int i = 0; i < 120; i++)
-		{
-			render_to_screen(context->targetTexture);
-		}
-		// Renders into sceneFBO where the texture is in sceneTexture
-		render_scene(&scene);
-		get_scene_geometry(&scene);
+  while (!glfwWindowShouldClose(context->window)) {
+    for (int i = 0; i < 120; i++) {
+      render_to_screen(context->targetTexture);
+    }
+    // Renders into sceneFBO where the texture is in sceneTexture
+    render_scene(&scene, context->sceneFBO);
 
-		for (int i = 0; i < 120; i++)
-		{
-			render_to_screen(context->sceneTexture);
-		}
-		// Renders into diffFBO where the texture is in diffTexture
-		get_image_mask(context->sceneTexture, context->targetTexture, 0);
-		double error1 = get_mean_pixel_value(context->diffTexture, 0);
-		for (int i = 0; i < 120; i++)
-		{
-			render_to_screen(context->diffTexture);
-		}
-		get_image_mask(context->sceneTexture, context->targetTexture, 1);
-		double error2 = get_mean_pixel_value(context->diffTexture, 1);
-		for (int i = 0; i < 120; i++)
-		{
-			render_to_screen(context->diffTexture);
-		}
-		get_image_mask(context->sceneTexture, context->targetTexture, 2);
-		double error3 = get_mean_pixel_value(context->diffTexture, 2);
-		for (int i = 0; i < 120; i++)
-		{
-			render_to_screen(context->diffTexture);
-		}
+    for (int i = 0; i < 120; i++) {
+      render_to_screen(context->sceneTexture);
+    }
+    // Renders into diffFBO where the texture is in diffTexture
+    get_image_mask(context->sceneTexture, context->targetTexture, 0);
+    double error1 = get_mean_pixel_value(context->diffTexture, 0);
+    std::cout << error1 << std::endl;
+    for (int i = 0; i < 120; i++) {
+      render_to_screen(context->diffTexture);
+    }
+    get_image_mask(context->sceneTexture, context->targetTexture, 1);
+    double error2 = get_mean_pixel_value(context->diffTexture, 1);
+    std::cout << error2 << std::endl;
+    for (int i = 0; i < 120; i++) {
+      render_to_screen(context->diffTexture);
+    }
+    get_image_mask(context->sceneTexture, context->targetTexture, 2);
+    double error3 = get_mean_pixel_value(context->diffTexture, 2);
+    std::cout << error3 << std::endl;
+    for (int i = 0; i < 120; i++) {
+      render_to_screen(context->diffTexture);
+    }
 
-		// Render to screen for visual debugging
+    // Render to screen for visual debugging
 
-		// TODO: Sort this out:
-		// Calculate Error
-		// uncomment if you wanna be spammed in the terminal
-		// std::cout << error1 + error2 + error3 << std::endl;
+    // TODO: Sort this out:
+    // Calculate Error
+    // uncomment if you wanna be spammed in the terminal
+    // std::cout << error1 + error2 + error3 << std::endl;
 
-		// break;
-	}
-	terminate_context();
+    std::cout << std::endl << std::endl;
 
-	return 0;
+    // break;
+  }
+  terminate_context();
+
+  return 0;
 }
 
 void init_context()
@@ -434,8 +430,7 @@ struct detected_lines *get_scene_geometry(struct scene *scene)
 	return geometry_lines;
 }
 
-void render_scene(struct scene *scene)
-{
+void render_scene(struct scene *scene, GLuint FBO) {
 	float planeSize = 10.0f;
 
 	// This is done here because it depends on the scene
@@ -480,7 +475,7 @@ void render_scene(struct scene *scene)
 	int modelLoc, viewLoc, projectionLoc, channelLoc;
 
 	// Bind to framebuffer so images displayed there rather than screen
-	glBindFramebuffer(GL_FRAMEBUFFER, context->sceneFBO);
+	glBindFramebuffer(GL_FRAMEBUFFER, FBO);
 	// Makes the sky blue innit
 	glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT);
@@ -852,4 +847,30 @@ void APIENTRY glDebugOutput(GLenum source, GLenum type, GLuint id,
 		break;
 	}
 	std::cout << std::endl << std::endl;
+}
+
+struct texture_fbo *create_texture_fbo() {
+	struct texture_fbo *tfbo = (struct texture_fbo *) malloc(sizeof(struct texture_fbo));
+	if (tfbo == NULL) {
+		exit(EXIT_FAILURE);
+	}
+	
+	/* Create the buffers */
+	glGenBuffers(1, &tfbo->frameBuffer);
+	glGenTextures(1, &tfbo->texture);
+
+	/* Bind texture to buffer */
+	bind_frame_buffer(tfbo->frameBuffer, tfbo->frameBuffer);
+
+	return tfbo;
+}
+
+/* Returns the scene frame buffer stored in the global context */
+GLuint get_scene_fbo() {
+	return context->sceneFBO;
+}
+
+/* Returns the scene texture stored in the global context */
+GLuint get_target_texture() {
+	return context->sceneTexture;
 }

--- a/backend/src/render.h
+++ b/backend/src/render.h
@@ -9,10 +9,20 @@
 extern "C" {
 void set_target_img(const char *str);
 
-void render_scene(struct scene *scene);
+void render_scene(struct scene *scene, GLuint FBO);
 double get_mean_pixel_value(GLuint texture, int color);
 void get_image_mask(GLuint texture1, GLuint texture2, GLuint channel);
 struct detected_lines *get_scene_geometry(struct scene *scene);
+
+struct texture_fbo *create_texture_fbo();
+GLuint get_scene_fbo();
+GLuint get_target_texture();
+
+struct texture_fbo {
+  GLuint texture;
+  GLuint frameBuffer;
+};
+
 int test_bed(const char *str, double x, double y, double z, double pitch, double yaw,
              double roll);
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,8 +1,8 @@
 import subprocess, tempfile, re
-from typing import Tuple, Any
+from typing import Tuple, Any, Optional
 
-BENCHMARK_SIZE: int = 50
-BENCHMARK_BATCH_SIZE: int = 5
+BENCHMARK_SIZE: int = 1
+BENCHMARK_BATCH_SIZE: int = 1
 BENCHMARK_MSG = f"""
 ======================================================
 ProbFX RoadMarkings Benchmarking Suite.
@@ -24,7 +24,7 @@ def start_benchmark(iteration: int) -> Tuple[int, Any, Any]:
                 stdout=output, stderr=output, shell=True))
 
 
-def extract_benchmark(output: bytes) -> float | None:
+def extract_benchmark(output: bytes) -> Optional[float]:
     if (res := re.match("FINAL ACCURACY: *(\d.*)[\n ]*", output.decode("utf-8"))) is not None:
         (acc,) = res.groups()
         return float(acc)
@@ -32,7 +32,7 @@ def extract_benchmark(output: bytes) -> float | None:
         print(f"Failed to extract accuracy from {output}")
 
 
-def end_benchmark(iteration: int, output: Any, process: Any) -> float | None:
+def end_benchmark(iteration: int, output: Any, process: Any) -> Optional[float]:
     print(f"Waiting on benchmark:{iteration:3}")
     process.wait()
     output.seek(0)

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,63 @@
+import subprocess, tempfile, re
+from typing import Tuple, Any
+
+BENCHMARK_SIZE: int = 50
+BENCHMARK_BATCH_SIZE: int = 5
+BENCHMARK_MSG = f"""
+======================================================
+ProbFX RoadMarkings Benchmarking Suite.
+------------------------------------------------------
+This scripts takes random parameters for the target 
+road, synthetically generates the road and gets the 
+accuracy.
+
+{BENCHMARK_SIZE} benchmarks are run in batches of {BENCHMARK_BATCH_SIZE}.
+"""
+
+
+def start_benchmark(iteration: int) -> Tuple[int, Any, Any]:
+    print(f"Starting Benchmark:  {iteration:3}")
+    output = tempfile.TemporaryFile()
+    return (iteration, output,
+            subprocess.Popen(
+                [f"cabal run ProbFX-RoadMarkings -- {iteration} | grep \"FINAL ACCURACY: \""],
+                stdout=output, stderr=output, shell=True))
+
+
+def extract_benchmark(output: bytes) -> float | None:
+    if (res := re.match("FINAL ACCURACY: *(\d.*)[\n ]*", output.decode("utf-8"))) is not None:
+        (acc,) = res.groups()
+        return float(acc)
+    else:
+        print(f"Failed to extract accuracy from {output}")
+
+
+def end_benchmark(iteration: int, output: Any, process: Any) -> float | None:
+    print(f"Waiting on benchmark:{iteration:3}")
+    process.wait()
+    output.seek(0)
+    contents = output.readlines()
+    output.close()
+    print(f"Completed Benchmark: {iteration:3}")
+    return extract_benchmark(contents[-1])
+
+
+def run_benchmarks(iterations: int) -> float:
+    print(BENCHMARK_MSG)
+    results: list[float] = []
+
+    for batch in range(0, iterations, BENCHMARK_BATCH_SIZE):
+        benchmarks = [start_benchmark(i) for i in range(
+            batch, min(batch + BENCHMARK_BATCH_SIZE, iterations))]
+        results.extend([res for bench in benchmarks if (res := end_benchmark(*bench)) is not None])
+
+    print("\nList of accuracies:")
+    print(' '.join([f"{round(f * 100, 2)}%" for f in results]))
+
+    mean : float = 100 * sum(results) / len(results)
+    print(f"Average accuracy: {round(mean,2):3}")
+    return mean
+
+
+if __name__ == "__main__":
+    run_benchmarks(BENCHMARK_SIZE)

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 source-repository-package
     type: git
     location: https://github.com/Functional-Labelling-Lab/ProbFX.git
-    tag: ba53faf6e7002b0a9304b6da38735ac5d5cd726c
+    tag: fe34e27e2c130fcff7e93239e3ef2fa9653aff5d
 
 packages: ./

--- a/src/Detection.hs
+++ b/src/Detection.hs
@@ -207,28 +207,14 @@ syntheticBenchmark errFun = do
     -- TODO: Implement
     envToScene :: Env RoadEnv -> Maybe Scene
     envToScene env = run $ runObsReader env $ do
-      -- mX     <- ask @RoadEnv #x
-      -- mY     <- ask @RoadEnv #y
-      -- mZ     <- ask @RoadEnv #z
-      -- mPitch <- ask @RoadEnv #pitch
-      -- mYaw   <- ask @RoadEnv #yaw
-      -- mRoll  <- ask @RoadEnv #roll
-      -- mError <- ask @RoadEnv #error
-
-      mX <- ask @RoadEnv #x
-      let mY = Just 0.2
-      -- mY <- ask @RoadEnv #y
-      let mZ = Just 0
-      -- mZ <- ask @RoadEnv #z
-      let mPitch = Just 0
-      -- mPitch <- ask @RoadEnv #pitch
-      let mYaw = Just 0
-      -- mYaw <- ask @RoadEnv #yaw
-      let mRoll = Just 0
-      -- mRoll <- ask @RoadEnv #roll
-      let mError = Just 0
-      -- mError <- ask @RoadEnv #error
-
+      mX     <- ask @RoadEnv #x
+      mY     <- ask @RoadEnv #y
+      mZ     <- ask @RoadEnv #z
+      mPitch <- ask @RoadEnv #pitch
+      mYaw   <- ask @RoadEnv #yaw
+      mRoll  <- ask @RoadEnv #roll
+      mError <- ask @RoadEnv #error
+      
       return $ case (mX, mY, mZ, mPitch, mYaw, mRoll, mError) of
         (Just x, Just y, Just z, Just pitch, Just yaw, Just roll, Just error) -> Just $ Scene {
           camera = Camera {

--- a/src/Detection.hs
+++ b/src/Detection.hs
@@ -154,7 +154,6 @@ channelError s = unsafePerformIO $ do
   second_error <- getMeanPixelValue 1
   findTextureDifference 2
   third_error <- getMeanPixelValue 2
-  print (first_error + second_error + third_error)
   return (first_error + second_error + third_error)
 
 

--- a/src/Detection.hs
+++ b/src/Detection.hs
@@ -200,7 +200,7 @@ syntheticBenchmark errFun = do
       let accuracy = sceneAccuracy scene predictedScene
       putStrLn $ "Scene:     " ++ show scene
       putStrLn $ "predicted: " ++ show predictedScene
-      putStrLn ("FINAL ACCURACY: " ++ show accuracy)
+      putStrLn $ "FINAL ACCURACY: " ++ show accuracy
 
       return accuracy
     
@@ -213,10 +213,9 @@ syntheticBenchmark errFun = do
       mPitch <- ask @RoadEnv #pitch
       mYaw   <- ask @RoadEnv #yaw
       mRoll  <- ask @RoadEnv #roll
-      mError <- ask @RoadEnv #error
-      
-      return $ case (mX, mY, mZ, mPitch, mYaw, mRoll, mError) of
-        (Just x, Just y, Just z, Just pitch, Just yaw, Just roll, Just error) -> Just $ Scene {
+
+      return $ case (mX, mY, mZ, mPitch, mYaw, mRoll) of
+        (Just x, Just y, Just z, Just pitch, Just yaw, Just roll) -> Just $ Scene {
           camera = Camera {
               x = x,
               y = y,
@@ -248,8 +247,8 @@ syntheticBenchmark errFun = do
     
     sceneToVec :: Scene -> [Double]
     sceneToVec scene = zipWith normalise
-      [xRange] --, yRange, zRange, pitchRange, yawRange, rollRange]
-      (map ($ camera scene) [x]) -- , y, z, pitch, yaw, roll])
+      [xRange, yRange, zRange, pitchRange, yawRange, rollRange]
+      (map ($ camera scene) [x, y, z, pitch, yaw, roll])
     
     xRange, yRange, zRange, pitchRange, yawRange, rollRange :: (Double, Double)
     xRange = (-0.4, 0.4)

--- a/src/Detection.hs
+++ b/src/Detection.hs
@@ -238,10 +238,7 @@ syntheticBenchmark errFun = do
 
     sceneAccuracy :: Scene -> Scene -> Double
     -- POST: 0 <= sceneAccuracy s s' <= 1
-    sceneAccuracy scene scene' = unsafePerformIO $ do
-        print sv
-        print sv'
-        return $ 1 - normalise (0, sqrt n) (euclidian sv sv')
+    sceneAccuracy scene scene' = 1 - normalise (0, sqrt n) (euclidian sv sv')
       where
         n  = fromIntegral $ length sv
         sv = sceneToVec scene

--- a/src/Detection.hs
+++ b/src/Detection.hs
@@ -6,12 +6,17 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 
-import Model ( Model, normal, uniform )
-import Env ( Env, Observables, Assign((:=)), (<:>), nil, get )
-import Inference.MH ( mh, mhRaw )
-import Sampler ( sampleIO, liftS )
-import Control.Algebra (Has)
+module Main (initRoadSample, main, trainModel) where
 
+import Debug.Trace ( trace )
+import System.Environment ( getArgs )
+import Data.Kind (Constraint)
+import Env ( Env, Observables, Assign((:=)), (<:>), nil, get )
+import System.Random (randomIO)
+import CppFFI (Scene (..), Camera (..), Texture,
+               getSceneFBO, renderScene, findTextureDifference,
+               getMeanPixelValue, testBed, setTargetImg, createTextureFBO,
+               TextureFBO (frameBuffer, texture), getTargetTexture, getHoughLines, screenBuffer)
 import Data.List (partition)
 import Foreign.C.String ( newCString )
 import CppFFI
@@ -22,13 +27,26 @@ import CppFFI
     testBed,
     setTargetImg,
     renderScene, getHoughLines, getSceneLines, Line )
+import Foreign.C.String
 import Foreign
     ( Storable(..), StablePtr(..), Int32, malloc, Storable(poke) )
-import Foreign.Marshal.Alloc ( malloc )
+import Foreign.Marshal.Alloc
 import OpenSum (Member)
 import System.IO.Unsafe ( unsafePerformIO )
 import Hough (compareLines, quadError, compError)
 import Foreign.C (CString)
+import System.IO.Unsafe
+import Hough (compareLines)
+import Model (Model, uniform, normal)
+import Sampler (sampleIO, liftS, sampleIOCustom, Sampler)
+import Inference.SIM (simulate)
+import Inference.MH (mh)
+import Control.Effect.ObsReader (ask)
+import Control.Carrier.ObsReader (runObsReader)
+import Control.Algebra (run, Has)
+import Data.Maybe (fromJust)
+import Text.Read (readMaybe)
+import Control.Monad (join)
 
 clamp :: (Double, Double) -> Double -> Double
 clamp (a, b) = min b . max a
@@ -45,8 +63,12 @@ type RoadEnv =
   , "error"     := Double
  ]
 
-initRoadSample :: forall env sig m.
-  (Observables env '["x", "y", "z", "pitch", "yaw", "roll"] Double, Has (Model env) sig m)
+emptyRoadEnv :: Env RoadEnv
+emptyRoadEnv = #x := [] <:> #y := [] <:> #z := [] <:> #pitch := [] <:> #yaw := [] <:> #roll := [] <:> #error := repeat 0 <:> nil
+
+
+initRoadSample :: forall env sig m. 
+  (Observables env '["x", "y", "z", "pitch", "yaw", "roll"] Double, Has (Model env) sig m) 
    => m Scene
 initRoadSample = do
   x     <- uniform @env (-0.5) 0.5 #x
@@ -87,7 +109,7 @@ trainModel errFun disp = do
     iterations = 10
 
 
-displayResults :: CString -> [Env RoadEnv] -> IO ()
+displayResults :: String -> [Env RoadEnv] -> IO ()
 displayResults imgPath traceMHs = do
     x     <- dispVar "x    " #x
     y     <- dispVar "y    " #y
@@ -96,7 +118,7 @@ displayResults imgPath traceMHs = do
     yaw   <- dispVar "yaw  " #yaw
     roll  <- dispVar "roll " #roll
     error <- dispVar "error" #error
-    testBed imgPath x y z pitch 0.0 roll
+    testBed imgPath Scene {camera=Camera{x=x, y=y, z=z, pitch=pitch, yaw=yaw, roll=roll}}
     return ()
   where
     displayIters = [1..10]
@@ -105,34 +127,154 @@ displayResults imgPath traceMHs = do
       putStrLn $ p ++ " = " ++ show (zip xs displayIters)
       return $ head xs
 
-main :: IO ()
-main = houghTrain "data/real_road.jpg"
-
 
 channelTrain :: String -> IO ()
 channelTrain imagePath = do
-  imgPath <- newCString imagePath
-  setTargetImg imgPath
-  trainModel channelError (displayResults imgPath)
-  where
-    channelError :: ErrorFunction
-    channelError s = unsafePerformIO $ do
-      scene <- malloc
-      poke scene s
-      renderScene scene
-      findTextureDifference 0
-      first_error <- getMeanPixelValue 0
-      findTextureDifference 1
-      second_error <- getMeanPixelValue 1
-      findTextureDifference 2
-      third_error <- getMeanPixelValue 2
-      print (first_error + second_error + third_error)
-      return (first_error + second_error + third_error)
+  setTargetImg imagePath
+  trainModel channelError (displayResults imagePath)
+
+channelError :: ErrorFunction
+channelError s = unsafePerformIO $ do
+  scene <- malloc
+  poke scene s
+  fbo <- getSceneFBO
+  renderScene scene fbo
+  findTextureDifference 0
+  first_error <- getMeanPixelValue 0
+  findTextureDifference 1
+  second_error <- getMeanPixelValue 1
+  findTextureDifference 2
+  third_error <- getMeanPixelValue 2
+  print (first_error + second_error + third_error)
+  return (first_error + second_error + third_error)
+
 
 houghTrain :: String -> IO ()
 houghTrain imagePath = do
-  imgPath <- newCString imagePath
-  trainModel (houghError $ getHoughLines imagePath) (displayResults imgPath)
+  trainModel (houghError $ getHoughLines imagePath) (displayResults imagePath)
+
+houghError :: [Line] -> ErrorFunction
+houghError sceneLines scene = compareLines quadError sceneLines (getSceneLines scene ) (10, 10)
+
+
+syntheticBenchmark :: ErrorFunction -> IO ()
+syntheticBenchmark errFun = do
+  args <- getArgs
+
+  seed <- case map readMaybe args of
+      [Just seed] -> return seed
+      _ -> do
+          seed <- randomIO
+          putStrLn ("No seed provided, using seed " ++ show seed)
+          return seed
+
+  benchmark seed
+  return ()
+  
   where
-    houghError :: [Line] -> ErrorFunction
-    houghError sceneLines scene = compareLines quadError sceneLines (getSceneLines scene ) (10, 10)
+    trainModelSeed :: Int -> Texture -> IO Scene
+    trainModelSeed seed = sampleIOCustom seed . trainModelSampler
+
+    trainModelSampler :: Texture -> Sampler Scene
+    trainModelSampler texture = do
+      traces <- mh 100 (roadGenerationModel @RoadEnv errFun) emptyRoadEnv ["x", "y", "z", "pitch", "yaw", "roll"]
+      return $ fromJust $ envToScene $ head traces
+
+    benchmark :: Int -> IO Double
+    benchmark seed = do
+      -- Create a scene to try and run the algorithm on.
+      (scene, _) <- sampleIOCustom seed $ simulate emptyRoadEnv (initRoadSample @RoadEnv)
+
+      -- Render this scene into an image
+      targetTextureFBO <- createTextureFBO
+      sceneMal <- malloc
+      poke sceneMal scene 
+      renderScene sceneMal (frameBuffer targetTextureFBO)
+      free sceneMal
+
+      -- Use mh to work backwards to the origional scene
+      putStrLn ("Running algorithm on input seed..." ++ show seed)
+      predictedScene <- trainModelSeed seed (texture targetTextureFBO)
+
+      -- get accuracy
+      let accuracy = sceneAccuracy scene predictedScene
+      putStrLn $ "Scene:     " ++ show scene
+      putStrLn $ "predicted: " ++ show predictedScene
+      putStrLn ("FINAL ACCURACY: " ++ show accuracy)
+
+      return accuracy
+    
+    -- TODO: Implement
+    envToScene :: Env RoadEnv -> Maybe Scene
+    envToScene env = run $ runObsReader env $ do
+      -- mX     <- ask @RoadEnv #x
+      -- mY     <- ask @RoadEnv #y
+      -- mZ     <- ask @RoadEnv #z
+      -- mPitch <- ask @RoadEnv #pitch
+      -- mYaw   <- ask @RoadEnv #yaw
+      -- mRoll  <- ask @RoadEnv #roll
+      -- mError <- ask @RoadEnv #error
+
+      mX <- ask @RoadEnv #x
+      let mY = Just 0.2
+      -- mY <- ask @RoadEnv #y
+      let mZ = Just 0
+      -- mZ <- ask @RoadEnv #z
+      let mPitch = Just 0
+      -- mPitch <- ask @RoadEnv #pitch
+      let mYaw = Just 0
+      -- mYaw <- ask @RoadEnv #yaw
+      let mRoll = Just 0
+      -- mRoll <- ask @RoadEnv #roll
+      let mError = Just 0
+      -- mError <- ask @RoadEnv #error
+
+      return $ case (mX, mY, mZ, mPitch, mYaw, mRoll, mError) of
+        (Just x, Just y, Just z, Just pitch, Just yaw, Just roll, Just error) -> Just $ Scene {
+          camera = Camera {
+              x = x,
+              y = y,
+              z = z,
+              pitch = pitch,
+              yaw = yaw,
+              roll = roll
+          }
+        }
+        _ -> Nothing
+
+    sceneAccuracy :: Scene -> Scene -> Double
+    -- POST: 0 <= sceneAccuracy s s' <= 1
+    sceneAccuracy scene scene' = 1 - normalise (0, sqrt n) (euclidian sv (sceneToVec scene'))
+      where
+        n  = fromIntegral $ length sv
+        sv = sceneToVec scene
+
+    normalise :: (Double, Double) -> Double -> Double
+    -- PRE: lower <= value <= upper
+    -- POST: 0 <= normalise (lower, upper) value <= 1
+    -- POST: a < b => normalise (l, u) a < normalise (l, u) b
+    normalise (lower, upper) value = (value - lower) / (upper - lower)
+
+    euclidian :: Floating a => [a] -> [a] -> a
+    euclidian = (sqrt . sum) ... zipWith (join (*) ... subtract)
+      where
+        (...) = (.)(.)(.)
+    
+    sceneToVec :: Scene -> [Double]
+    sceneToVec scene = zipWith normalise
+      [xRange] --, yRange, zRange, pitchRange, yawRange, rollRange]
+      (map ($ camera scene) [x]) -- , y, z, pitch, yaw, roll])
+    
+    xRange, yRange, zRange, pitchRange, yawRange, rollRange :: (Double, Double)
+    xRange = (-0.4, 0.4)
+    yRange = (0.05, 2)
+    zRange = (-1, 1)
+    pitchRange = (-0.2, 0.2)
+    yawRange = (0.2, 0.3)
+    rollRange = (0.2, 0.3)
+
+
+main :: IO ()
+-- main = houghTrain "data/real_road.jpg"
+-- main = trainModel "data/read_road.jpg" channelError
+main = syntheticBenchmark channelError


### PR DESCRIPTION
## Description
Create a basic synthetic benchmarking suite using randomly generated scenes

Based on the previous work of [synthetic benchmarking](https://github.com/Functional-Labelling-Lab/ProbFX-RoadMarkings/pull/12) (too complex of a rebase, and changes to Cpp side so better to reimplement)

## Goals
- *generate random scenes*
- *train on random scenes with configurable error function*
- *run benchmarks through easy interface (e.g toplevel makefile)*

## Changes
- [x] *Getting error from scenes*
- [x] *Running training on scenes*
- [x] *Multiprocessing from python script*
- [x] *Passing scene references*
- [ ] *In-depth results (error per variable)*
- [ ] *Haskell based benchmarking* 